### PR TITLE
Various fixes and improvements.

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ module.exports = function (opts) {
     var compile = function () {
       var transformOpts = _.clone(opts.options);
 
-      to5.transformFile(opts.dest, transformOpts, function (err, result) {
+      to5.transformFile(src, transformOpts, function (err, result) {
         if (err) return next(err);
         write(result.code);
       });

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ module.exports = function (opts) {
 
     var dest = path.join(opts.dest, url);
     var src  = path.join(opts.src, url);
-    var srcStat, destStat;
+    var srcStat;
 
     var write = function (transformed) {
       fs.writeFile(dest, transformed, function (err) {
@@ -41,7 +41,7 @@ module.exports = function (opts) {
     };
 
     var destExists = function () {
-      if (cache[url] < +destStat.mtime) {
+      if (cache[url] !== +srcStat.mtime) {
         compile();
       } else {
         next();
@@ -55,7 +55,6 @@ module.exports = function (opts) {
 
       fs.stat(dest, function (err, stat) {
         if (err && err.code !== 'ENOENT') return next(err);
-        destStat = stat;
 
         if (!err && cache[dest]) {
           destExists();

--- a/index.js
+++ b/index.js
@@ -20,13 +20,18 @@ module.exports = function (opts) {
     var src  = path.join(opts.src, url);
     var srcStat;
 
+    var send = function (data) {
+      res.set('Content-Type', 'application/javascript');
+      res.end(data);
+    };
+
     var write = function (transformed) {
       fs.writeFile(dest, transformed, function (err) {
         if (err) {
           next(err);
         } else {
           cache[url] = +srcStat.mtime;
-          next();
+          send(transformed);
         }
       });
     };
@@ -44,7 +49,10 @@ module.exports = function (opts) {
       if (cache[url] !== +srcStat.mtime) {
         compile();
       } else {
-        next();
+        fs.readFile(dest, function (err, data) {
+          if (err) return next(err);
+          send(data);
+        });
       }
     };
 

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ module.exports = function (opts) {
     src:     "assets"
   });
 
-  var cache = {};
+  var cache = Object.create(null);
 
   return function (req, res, next) {
     var url = req.url;

--- a/index.js
+++ b/index.js
@@ -18,14 +18,14 @@ module.exports = function (opts) {
 
     var dest = path.join(opts.dest, url);
     var src  = path.join(opts.src, url);
-    var destStat;
+    var srcStat, destStat;
 
     var write = function (transformed) {
       fs.writeFile(dest, transformed, function (err) {
         if (err) {
           next(err);
         } else {
-          cache[url] = Date.now();
+          cache[url] = +srcStat.mtime;
           next();
         }
       });
@@ -51,6 +51,7 @@ module.exports = function (opts) {
     fs.stat(src, function (err, stat) {
       if (err && err.code === 'ENOENT') return next();
       else if (err) return next(err);
+      srcStat = stat;
 
       fs.stat(dest, function (err, stat) {
         if (err && err.code !== 'ENOENT') return next(err);

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   "bugs": {
     "url": "https://github.com/sebmck/6to5-connect/issues"
   },
-  "preferGlobal": true,
   "dependencies": {
     "6to5-core": "3.0.0",
     "lodash": "2.4.1",


### PR DESCRIPTION
Not sure if anyone is using this, or maybe people just expect something different from middleware? :-)

Most significantly, this pull request actually serves the transformed result for all requests it intercepts. (Previously, a request for a JS-file would compile, write to cache, but then call `next()`. So some other middleware had to serve the cache file, or it'd result in something weird like a 404 or just the source file with `express.static`.)

The node.js docs recommend against using `fs.exists`. Previously, the code also compared cache mtimes instead of source mtimes, which doesn't make much sense.

On a separate branch, I've replaced disk cache with in-memory cache and added source map support. But that's not in this PR, because I'm not sure how desirable the former is. I only intend to use this for development, and not production builds. See: https://github.com/AngryBytes/6to5-connect/compare/master...in-memory
