### PR TITLE
Transform all file urls to babel:///foo/bar.js for easier usage

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,6 +39,7 @@ module.exports = function (opts) {
 
     var compile = function () {
       var transformOpts = _.clone(opts.options);
+      transformOpts.sourceFileName = 'babel:///' + src.replace(opts.src, '');
       babel.transformFile(src, transformOpts, function (err, result) {
         if (err) {
           next(err);


### PR DESCRIPTION
This is similar to how webpack sets the urls to webpack:///.
If this is not done, the URLs end up being /absolute/path/foo/bar which
is not very useful in such middleware anyway imho.
