### PR TITLE
Support Babel 6

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ module.exports = function (opts) {
 
   return function (req, res, next) {
     if (opts.ignore.test(req.url)) return next();
-    if (!babel.canCompile(req.url)) return next();
+    if (!babel.util.canCompile(req.url)) return next();
 
     var pathname = path.normalize(url.parse(req.url).pathname);
     var dest = path.join(opts.dest, pathname);

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/babel/babel-connect/issues"
   },
   "dependencies": {
-    "babel-core": "^5.0.0",
+    "babel-core": "^6.2.1",
     "lodash": "2.4.1",
     "mkdirp": "^0.5.0",
     "through": "2.3.4"


### PR DESCRIPTION
Babel API has changed in 6.x. Changed babel-connect to use the new API.
