### PR TITLE
Bump version number to 6.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "babel-connect",
   "description": "babel connect middleware plugin",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "author": "Sebastian McKenzie <sebmck@gmail.com>",
   "homepage": "https://github.com/babel/babel-connect",
   "repository": {


### PR DESCRIPTION
Bump version number so this can be published to npm.  Resolves https://github.com/babel/babel-connect/issues/9
